### PR TITLE
model update fix (client side) + more fine-grained locks (server side)

### DIFF
--- a/server/bastionai_app/src/utils.rs
+++ b/server/bastionai_app/src/utils.rs
@@ -45,7 +45,7 @@ pub async fn stream_data(
 ) -> Response<ReceiverStream<Result<Chunk, Status>>> {
     let (tx, rx) = mpsc::channel(4);
 
-    let raw_bytes: Vec<u8> = artifact.data.into();
+    let raw_bytes: Vec<u8> = artifact.data.into_inner().unwrap().into();
     tokio::spawn(async move {
         for (i, bytes) in raw_bytes.chunks(chunk_size).enumerate() {
             tx.send(Ok(Chunk {


### PR DESCRIPTION
Fix model update on the client side when using `client.fetch_model_weights`.
Fix aggressive locking on the server side with more fine-grained locks:
- One `RwLock` per collection (datasets and modules) used to access data (read) and add/remove data (write) -> this allows several model/dataset accesses at the same time but block all accesses while updating the collection.
- One `RwLock` per module or dataset -> there's no need to block all accesses to all models when training one, with this second level of locks, we only need to acquire a read lock on the module collection and a write lock on the module's lock. This means all other models can still be accessed while training the locked model and it also ensure that the locked model cannot be fetched or tested while it is being trained. I also changed the train method so that it takes &mut self instead of &self to force the use a write lock guard even though an immutable borrow would suffice as changes are made in C++... Without this change, it would be possible to train with read guards which leads to races!!!