### PR TITLE
Training DL Models with Multiple Datasets

### DIFF
--- a/client/bastionai/learner.py
+++ b/client/bastionai/learner.py
@@ -185,7 +185,6 @@ class RemoteLearner:
             )
         else:
             self.model_ref = model
-
         if isinstance(remote_dataset, list):
             if is_grpc_type(remote_dataset[0], Reference):
                 self.remote_dataset = [RemoteDataset(client, v) for v in remote_dataset]

--- a/client/protos/remote_torch.proto
+++ b/client/protos/remote_torch.proto
@@ -40,14 +40,14 @@ message Empty {
 message TrainConfig {
     // Configuration for training sent to BastionAI.
     Reference model = 1;
-    Reference dataset = 2;
+    repeated Reference dataset = 2;
     int32 batch_size = 3;
     int32 epochs = 4;
     string device = 5;
     string metric = 6;
     float eps = 7;
     float max_grad_norm = 8;
-    float metric_eps = 9;
+    repeated float metric_eps = 9;
     
     oneof optimizer {
         // The type of optimizer to be used during training.
@@ -80,11 +80,11 @@ message TrainConfig {
 
 message TestConfig {
     Reference model = 1;
-    Reference dataset = 2;
+    repeated Reference dataset = 2;
     int32 batch_size = 3;
     string device = 4;
     string metric = 5;
-    float metric_eps = 6;
+    repeated float metric_eps = 6;
 }
 
 message References {

--- a/server/bastionai_learning/src/lib.rs
+++ b/server/bastionai_learning/src/lib.rs
@@ -1,21 +1,26 @@
-pub mod optim;
-pub mod nn;
-pub mod serialization;
-pub mod procedures;
 pub mod data;
+pub mod nn;
+pub mod optim;
+pub mod procedures;
+pub mod serialization;
 
 #[cfg(test)]
 mod tests {
-    use tch::{TrainableCModule, Device, Tensor, TchError, Kind};
-    use tch::nn::VarStore;
     use std::sync::{Arc, RwLock};
+    use tch::nn::VarStore;
+    use tch::{Device, Kind, TchError, Tensor, TrainableCModule};
 
-    use crate::data::privacy_guard::{PrivacyContext, PrivacyBudget, PrivacyGuard, BatchDependence};
+    use crate::data::privacy_guard::{
+        BatchDependence, PrivacyBudget, PrivacyContext, PrivacyGuard,
+    };
     use crate::nn::{LossType, Module};
-    use crate::optim::{SGD, Optimizer};
+    use crate::optim::{Optimizer, SGD};
 
     fn l2_loss(output: &Tensor, target: &Tensor) -> Result<Tensor, TchError> {
-        output.f_sub(&target)?.f_norm_scalaropt_dim(2, &[1], false)?.f_mean(Kind::Float)
+        output
+            .f_sub(&target)?
+            .f_norm_scalaropt_dim(2, &[1], false)?
+            .f_mean(Kind::Float)
     }
 
     #[test]
@@ -65,14 +70,20 @@ mod tests {
             Tensor::of_slice::<f32>(&[2.]),
         ];
 
-        let context = Arc::new(RwLock::new(PrivacyContext::new(PrivacyBudget::NotPrivate, 4)));
+        let context = Arc::new(RwLock::new(PrivacyContext::new(
+            PrivacyBudget::NotPrivate,
+            4,
+        )));
 
         for _ in 0..100 {
             for (x, t) in data.iter().zip(target.iter()) {
                 let x = PrivacyGuard::new(x.copy(), BatchDependence::Dependent, context.clone());
                 let t = PrivacyGuard::new(t.copy(), BatchDependence::Dependent, context.clone());
                 let y = forward.forward(vec![x]).unwrap();
-                let loss = y.f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean).unwrap().0;
+                let loss = y
+                    .f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean)
+                    .unwrap()
+                    .0;
                 optimizer.zero_grad().unwrap();
                 loss.backward();
                 optimizer.step().unwrap();
@@ -97,15 +108,21 @@ mod tests {
             Tensor::of_slice::<f32>(&[1.0, 0.4]).f_view([2, 1]).unwrap(),
         ];
 
-        let context = Arc::new(RwLock::new(PrivacyContext::new(PrivacyBudget::Private(300.1), 4)));
-        
+        let context = Arc::new(RwLock::new(PrivacyContext::new(
+            PrivacyBudget::Private(300.1),
+            4,
+        )));
+
         for _ in 0..200 {
             for (x, t) in data.iter().zip(target.iter()) {
                 let x = PrivacyGuard::new(x.copy(), BatchDependence::Dependent, context.clone());
                 let t = PrivacyGuard::new(t.copy(), BatchDependence::Dependent, context.clone());
 
                 let y = forward.forward(vec![x]).unwrap();
-                let loss = y.f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean).unwrap().0;
+                let loss = y
+                    .f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean)
+                    .unwrap()
+                    .0;
                 optimizer.zero_grad().unwrap();
                 loss.backward();
                 optimizer.step().unwrap();
@@ -113,7 +130,11 @@ mod tests {
         }
         let w = &optimizer.parameters.into_inner().unwrap()[0];
         w.print();
-        assert!(l2_loss(w, &Tensor::of_slice::<f32>(&[2.])).unwrap().double_value(&[]) < 0.1);
+        assert!(
+            l2_loss(w, &Tensor::of_slice::<f32>(&[2.]))
+                .unwrap()
+                .double_value(&[])
+                < 0.1
+        );
     }
-
 }

--- a/server/protos/remote_torch.proto
+++ b/server/protos/remote_torch.proto
@@ -40,14 +40,14 @@ message Empty {
 message TrainConfig {
     // Configuration for training sent to BastionAI.
     Reference model = 1;
-    Reference dataset = 2;
+    repeated Reference dataset = 2;
     int32 batch_size = 3;
     int32 epochs = 4;
     string device = 5;
     string metric = 6;
     float eps = 7;
     float max_grad_norm = 8;
-    float metric_eps = 9;
+    repeated float metric_eps = 9;
     
     oneof optimizer {
         // The type of optimizer to be used during training.
@@ -80,11 +80,11 @@ message TrainConfig {
 
 message TestConfig {
     Reference model = 1;
-    Reference dataset = 2;
+    repeated Reference dataset = 2;
     int32 batch_size = 3;
     string device = 4;
     string metric = 5;
-    float metric_eps = 6;
+    repeated float metric_eps = 6;
 }
 
 message References {

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -62,6 +62,38 @@ class LinRegTest(unittest.TestCase):
             bastion_lreg_model = remote_learner.get_model()
         self.assertEqual(bastion_lreg_model, lreg_model)
 
+    def test_multi_datasets_upload(self):
+        with Connection("localhost", 50051, default_secret=b"") as client:
+            _ = client.RemoteDataset(
+                train_dataset,
+                test_dataset,
+                name="1D Linear Regression",
+                description="Dummy 1D Linear Regression Dataset (param is 2)",
+                privacy_limit=8320.1,
+            )
+            _ = client.RemoteDataset(
+                train_dataset,
+                test_dataset,
+                name="1D Linear Regression",
+                description="Dummy 1D Linear Regression Dataset (param is 2)",
+                privacy_limit=8320.1,
+            )
+            remote_refs = list(
+                filter(lambda a: "test" not in a.name, client.get_available_datasets())
+            )
+            remote_learner = client.RemoteLearner(
+                lreg_model,
+                remote_dataset=remote_refs,
+                loss="l2",
+                optimizer=SGD(lr=0.1),
+                model_name="Linear 1x1",
+                model_description="1D Linear Regression Model",
+                expand=False,
+                max_batch_size=2,
+            )
+            bastion_lreg_model = remote_learner.get_model()
+        self.assertEqual(bastion_lreg_model, lreg_model)
+
 
 def setUpModule():
     global train_dataset, test_dataset, lreg_model


### PR DESCRIPTION
[**feature**] 
This PR adds a new feature to **BastionAI** by making it possible to train on multiple datasets.
After accepting the references to the datasets, the trainer fetches the respective datasets from the store and loops over them.

For a start, the protocol is updated to this state:
```protobuf
message TrainConfig {
    // Configuration for training sent to BastionAI.
    Reference model = 1;
    repeated Reference dataset = 2;
    int32 batch_size = 3;
    int32 epochs = 4;
    string device = 5;
    string metric = 6;
    float eps = 7;
    float max_grad_norm = 8;
    repeated float metric_eps = 9;
    ...
}

message TestConfig {
    Reference model = 1;
    repeated Reference dataset = 2;
    int32 batch_size = 3;
    string device = 4;
    string metric = 5;
    repeated float metric_eps = 6;
}
```
The `TrainConfig` now accepts a list of dataset references. Likewise, the `TestConfig` also takes a list of references. 
This makes it possible to test on any of the test datasets of multiple datasets used in training.