### PR TITLE
Added a step in the CI to initialize submodules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
+      
+      # Initialize submodules
+      - name: Init submodules
+        run: |
+          git submodule init
+          git submodule update
 
       # Reuse previous wheels if the client is unchanged
       - name: Cache wheels


### PR DESCRIPTION
The client-build will fail once attestation is merged if the pybind11 submodule is not initialized, a step is added to ensure the submodule is initialized.