### PR TITLE
Add optional authentication to BastionLab

### DIFF
--- a/client/src/bastionlab/__init__.py
+++ b/client/src/bastionlab/__init__.py
@@ -7,4 +7,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "pb"))
 
 from .client import Connection
 from .remote_polars import RemoteLazyFrame, RemoteLazyGroupBy
-from .keys import SigningKey, PublicKey
+from .keys import Identity

--- a/client/src/bastionlab/client.py
+++ b/client/src/bastionlab/client.py
@@ -142,7 +142,7 @@ class AuthPlugin(grpc.AuthMetadataPlugin):
 @dataclass
 class Connection:
     host: str
-    port: int
+    port: Optional[int] = 50056
     signing_key: Optional[SigningKey] = None
     channel: Any = None
     token: Optional[bytes] = None
@@ -150,7 +150,9 @@ class Connection:
     server_name: Optional[str] = "bastionlab-server"
 
     @staticmethod
-    def _verify_user(server_target, server_creds, options, signing_key: Optional[SigningKey]=None):
+    def _verify_user(
+        server_target, server_creds, options, signing_key: Optional[SigningKey] = None
+    ):
         """
         Set up initial connection to BastionLab for verification
         if pubkey not known:
@@ -177,7 +179,7 @@ class Connection:
             metadata += ((f"signature-{(pubkey_hex)}-bin", signed),)
 
             return stub.CreateSession(CLIENT_INFO, metadata=metadata).token
-        
+
         stub.CreateSession(CLIENT_INFO)
         return None
 
@@ -212,7 +214,7 @@ class Connection:
 
         channel_cred = (
             server_creds
-            if self.signing_key is None 
+            if self.signing_key is None
             else server_creds
             if self.token is None
             else grpc.composite_channel_credentials(
@@ -228,9 +230,7 @@ class Connection:
         if self.token is not None:
             daemon = Thread(
                 target=self._heart_beat,
-                args=(
-                    stub,
-                ),
+                args=(stub,),
                 daemon=True,
                 name="HeartBeat",
             )

--- a/client/src/bastionlab/client.py
+++ b/client/src/bastionlab/client.py
@@ -179,9 +179,9 @@ class Connection:
             metadata += ((f"signature-{(pubkey_hex)}-bin", signed),)
 
             return stub.CreateSession(CLIENT_INFO, metadata=metadata).token
-
-        stub.CreateSession(CLIENT_INFO)
-        return None
+        else:
+            stub.CreateSession(CLIENT_INFO)
+            return None
 
     @property
     def client(self) -> Client:

--- a/client/src/bastionlab/client.py
+++ b/client/src/bastionlab/client.py
@@ -53,10 +53,8 @@ class Client:
     def __init__(
         self,
         stub: BastionLabStub,
-        token: bytes,
     ):
         self.stub = stub
-        self.token = token
 
     def send_df(
         self,
@@ -145,13 +143,14 @@ class AuthPlugin(grpc.AuthMetadataPlugin):
 class Connection:
     host: str
     port: int
-    signing_key: SigningKey
+    signing_key: Optional[SigningKey] = None
     channel: Any = None
+    token: Optional[bytes] = None
     _client: Optional[Client] = None
     server_name: Optional[str] = "bastionlab-server"
 
     @staticmethod
-    def _verify_user(server_target, server_creds, options, signing_key: SigningKey):
+    def _verify_user(server_target, server_creds, options, signing_key: Optional[SigningKey]=None):
         """
         Set up initial connection to BastionLab for verification
         if pubkey not known:
@@ -167,16 +166,20 @@ class Connection:
         metadata = ()
         data: bytes = CLIENT_INFO.SerializeToString()
 
-        challenge = stub.GetChallenge(Empty()).value
+        if signing_key is not None:
+            challenge = stub.GetChallenge(Empty()).value
 
-        metadata += (("challenge-bin", challenge),)
-        to_sign = b"create-session" + challenge + data
+            metadata += (("challenge-bin", challenge),)
+            to_sign = b"create-session" + challenge + data
 
-        pubkey_hex = signing_key.pubkey.hash.hex()
-        signed = signing_key.sign(to_sign)
-        metadata += ((f"signature-{(pubkey_hex)}-bin", signed),)
+            pubkey_hex = signing_key.pubkey.hash.hex()
+            signed = signing_key.sign(to_sign)
+            metadata += ((f"signature-{(pubkey_hex)}-bin", signed),)
 
-        return stub.CreateSession(CLIENT_INFO, metadata=metadata).token
+            return stub.CreateSession(CLIENT_INFO, metadata=metadata).token
+        
+        stub.CreateSession(CLIENT_INFO)
+        return None
 
     @property
     def client(self) -> Client:
@@ -189,10 +192,9 @@ class Connection:
         if self._client is not None:
             self.__exit__(None, None, None)
 
-    def _heart_beat(self, stub, token):
-
+    def _heart_beat(self, stub):
         while True:
-            stub.RefreshSession(Empty(), metadata=(("accesstoken-bin", token),))
+            stub.RefreshSession(Empty(), metadata=(("accesstoken-bin", self.token),))
             sleep(HEART_BEAT_TICK)
 
     def __enter__(self) -> Client:
@@ -204,15 +206,17 @@ class Connection:
         connection_options = (("grpc.ssl_target_name_override", self.server_name),)
 
         # Verify user by creating session
-        token = Connection._verify_user(
+        self.token = Connection._verify_user(
             server_target, server_creds, connection_options, self.signing_key
         )
 
         channel_cred = (
             server_creds
-            if token is None
+            if self.signing_key is None 
+            else server_creds
+            if self.token is None
             else grpc.composite_channel_credentials(
-                server_creds, grpc.metadata_call_credentials(AuthPlugin(token))
+                server_creds, grpc.metadata_call_credentials(AuthPlugin(self.token))
             )
         )
 
@@ -221,20 +225,19 @@ class Connection:
         )
         stub = BastionLabStub(self.channel)
 
-        daemon = Thread(
-            target=self._heart_beat,
-            args=(
-                stub,
-                token,
-            ),
-            daemon=True,
-            name="HeartBeat",
-        )
-        daemon.start()
+        if self.token is not None:
+            daemon = Thread(
+                target=self._heart_beat,
+                args=(
+                    stub,
+                ),
+                daemon=True,
+                name="HeartBeat",
+            )
+            daemon.start()
 
         self._client = Client(
             stub,
-            token,
         )
 
         return self._client

--- a/client/src/bastionlab/client.py
+++ b/client/src/bastionlab/client.py
@@ -143,7 +143,7 @@ class AuthPlugin(grpc.AuthMetadataPlugin):
 class Connection:
     host: str
     port: Optional[int] = 50056
-    signing_key: Optional[SigningKey] = None
+    identity: Optional[SigningKey] = None
     channel: Any = None
     token: Optional[bytes] = None
     _client: Optional[Client] = None
@@ -209,12 +209,12 @@ class Connection:
 
         # Verify user by creating session
         self.token = Connection._verify_user(
-            server_target, server_creds, connection_options, self.signing_key
+            server_target, server_creds, connection_options, self.identity
         )
 
         channel_cred = (
             server_creds
-            if self.signing_key is None
+            if self.identity is None
             else server_creds
             if self.token is None
             else grpc.composite_channel_credentials(

--- a/client/src/bastionlab/keys.py
+++ b/client/src/bastionlab/keys.py
@@ -88,13 +88,17 @@ class SigningKey:
         return SigningKey(ec.generate_private_key(ec.SECP256R1()))
 
     @staticmethod
-    def from_pem_or_generate(
+    def keygen(
         path: str, password: Optional[bytes] = None
     ) -> "SigningKey":
-        if os.path.exists(path):
-            return SigningKey.from_pem(path, password)
+        signing_key_path = path
+        pub_key_path = path+'.pub'
+        if os.path.exists(signing_key_path):
+            return SigningKey.from_pem(signing_key_path, password)
         else:
-            return SigningKey.generate().save_pem(path, password)
+            priv_key = SigningKey.generate().save_pem(signing_key_path, password)
+            priv_key.pubkey.save_pem(pub_key_path)
+            return priv_key
 
     @staticmethod
     def from_pem(path: str, password: Optional[bytes] = None) -> "SigningKey":

--- a/client/src/bastionlab/keys.py
+++ b/client/src/bastionlab/keys.py
@@ -121,3 +121,15 @@ class SigningKey:
         content: bytes, password: Optional[bytes] = None
     ) -> "SigningKey":
         return SigningKey(serialization.load_pem_private_key(content, password))
+
+
+class Identity:
+    @staticmethod
+    def create(
+        name: Optional[str] = "bastionlab-identity", password: Optional[bytes] = None
+    ) -> SigningKey:
+        return SigningKey.keygen(name, password)
+
+    @staticmethod
+    def load(name: str) -> SigningKey:
+        return SigningKey.keygen(name, None)

--- a/client/src/bastionlab/keys.py
+++ b/client/src/bastionlab/keys.py
@@ -88,11 +88,9 @@ class SigningKey:
         return SigningKey(ec.generate_private_key(ec.SECP256R1()))
 
     @staticmethod
-    def keygen(
-        path: str, password: Optional[bytes] = None
-    ) -> "SigningKey":
+    def keygen(path: str, password: Optional[bytes] = None) -> "SigningKey":
         signing_key_path = path
-        pub_key_path = path+'.pub'
+        pub_key_path = path + ".pub"
         if os.path.exists(signing_key_path):
             return SigningKey.from_pem(signing_key_path, password)
         else:

--- a/client/src/bastionlab/keys.py
+++ b/client/src/bastionlab/keys.py
@@ -132,4 +132,4 @@ class Identity:
 
     @staticmethod
     def load(name: str) -> SigningKey:
-        return SigningKey.keygen(name, None)
+        return SigningKey.from_pem(name, None)

--- a/server/src/authentication.rs
+++ b/server/src/authentication.rs
@@ -109,10 +109,10 @@ impl KeyManagement {
                     })?;
                     return Ok(());
                 }
-                Err(Status::permission_denied(format!(
+                return Err(Status::permission_denied(format!(
                     "{:?} not authenticated!",
                     public_key_hash
-                )))?
+                )));
             }
             None => Err(Status::permission_denied(format!(
                 "No signature provided for public key {}",

--- a/server/src/authentication.rs
+++ b/server/src/authentication.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    fs::{self, read},
+    fs::{self, read, ReadDir},
     net::SocketAddr,
     path::{Path, PathBuf},
 };
@@ -23,37 +23,44 @@ pub type PubKey = Vec<u8>;
 
 #[derive(Debug, Default, Clone)]
 pub struct KeyManagement {
-    pub_keys: HashMap<String, PubKey>,
+    owners: HashMap<String, PubKey>,
+    users: HashMap<String, PubKey>,
 }
 
 impl KeyManagement {
     fn read_from_file(path: PathBuf) -> Result<(String, PubKey), Status> {
         let file = &read(path)?;
         let (_, Pem { contents, .. }) = x509_parser::pem::parse_x509_pem(&file[..])
-            .map_err(|e| Status::aborted(e.to_string()))?;
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
 
         let hash = hex::encode(digest(&SHA256, &contents[..]));
         Ok((hash, contents))
     }
 
-    pub fn load_from_dir(path: String) -> Result<Self, Status> {
-        let mut pub_keys: HashMap<String, PubKey> = HashMap::new();
-
-        if !Path::new(&path).is_dir() {
-            Err(Status::aborted("Please provide a directory!"))?
-        }
-
-        let paths = fs::read_dir(path.clone())?;
-
-        for path in paths {
+    pub fn get_hash_and_keys(dir: ReadDir) -> Result<HashMap<String, PubKey>, Status> {
+        let mut res = HashMap::new();
+        for path in dir {
             let path = path?;
             let file = path.path();
 
             let (hash, raw) = KeyManagement::read_from_file(file)?;
-            pub_keys.insert(hash, raw);
+            res.insert(hash, raw);
+        }
+        Ok(res)
+    }
+
+    pub fn load_from_dir(path: String) -> Result<Self, Status> {
+        if !Path::new(&path).is_dir() {
+            Err(Status::aborted("Please provide a public keys directory!"))?
         }
 
-        Ok(KeyManagement { pub_keys })
+        let owners = fs::read_dir(path.clone() + "/owners")?;
+        let users = fs::read_dir(path + "/users")?;
+
+        let owners = KeyManagement::get_hash_and_keys(owners)?;
+        let users = KeyManagement::get_hash_and_keys(users)?;
+
+        Ok(KeyManagement { owners, users })
     }
 
     pub fn verify_signature(
@@ -71,9 +78,10 @@ impl KeyManagement {
         */
         match header.get_bin(format!("signature-{}-bin", public_key_hash)) {
             Some(signature) => {
-                let keys = &self.pub_keys;
+                let keys = &mut self.owners.iter().chain(self.users.iter());
 
-                if let Some(raw_pub) = keys.get(&public_key_hash.to_string()) {
+                if let Some((_, raw_pub)) = keys.find(|&(k, _v)| public_key_hash.to_string().eq(k))
+                {
                     let public_key = spki::SubjectPublicKeyInfo::try_from(raw_pub.as_ref())
                         .map_err(|_| {
                             Status::invalid_argument(format!(
@@ -101,7 +109,7 @@ impl KeyManagement {
                     })?;
                     return Ok(());
                 }
-                Err(Status::aborted(format!(
+                Err(Status::permission_denied(format!(
                     "{:?} not authenticated!",
                     public_key_hash
                 )))?
@@ -137,12 +145,15 @@ pub fn verify_ip(stored: &SocketAddr, recv: &SocketAddr) -> bool {
     stored.ip().eq(&recv.ip())
 }
 
-pub fn get_token<T>(req: &Request<T>) -> Result<Bytes, Status> {
+pub fn get_token<T>(req: &Request<T>, auth_enabled: bool) -> Result<Option<Bytes>, Status> {
+    if !auth_enabled {
+        return Ok(None);
+    }
     let meta = req
         .metadata()
         .get_bin("accesstoken-bin")
         .ok_or_else(|| Status::invalid_argument("No accesstoken in request metadata"))?;
-    Ok(meta
-        .to_bytes()
-        .map_err(|_| Status::invalid_argument("Could not decode accesstoken"))?)
+    Ok(Some(meta.to_bytes().map_err(|_| {
+        Status::invalid_argument("Could not decode accesstoken")
+    })?))
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -91,25 +91,27 @@ impl DataFrameArtifact {
 pub struct Session {
     user_ip: SocketAddr,
     expiry: SystemTime,
-    public_key: String,
     client_info: ClientInfo,
 }
 
 #[derive(Debug, Default)]
 pub struct BastionLabState {
     dataframes: Arc<RwLock<HashMap<String, DataFrameArtifact>>>,
-    keys: Mutex<KeyManagement>,
+    keys: Mutex<Option<KeyManagement>>,
     sessions: Arc<RwLock<HashMap<[u8; 32], Session>>>,
     session_expiry: u64,
+    auth_enabled: bool,
 }
 
 impl BastionLabState {
-    fn new(keys: KeyManagement, session_expiry: u64) -> Self {
+    fn new(keys: Option<KeyManagement>, session_expiry: u64) -> Self {
+        let auth_enabled = keys.is_some();
         Self {
             dataframes: Arc::new(RwLock::new(HashMap::new())),
             keys: Mutex::new(keys),
             sessions: Default::default(),
             session_expiry,
+            auth_enabled,
         }
     }
 
@@ -243,23 +245,30 @@ Reason: {}",
     }
 
     fn verify_request<T>(&self, req: &Request<T>) -> Result<(), Status> {
-        let remote_addr = &req.remote_addr();
-        let token = get_token(req)?;
-        let mut tokens = self.sessions.write().unwrap();
-        if let Some(recv_ip) = remote_addr {
-            if let Some(Session {
-                user_ip, expiry, ..
-            }) = tokens.get(token.as_ref())
-            {
-                let curr_time = SystemTime::now();
-                if !verify_ip(&user_ip, &recv_ip) {
-                    return Err(Status::aborted("Unknown IP Address!"));
-                }
-                if curr_time.gt(expiry) {
-                    tokens.remove(token.as_ref());
-                    return Err(Status::aborted("Session Expired"));
+        let lock = self.keys.lock().unwrap();
+        match *lock {
+            Some(_) => {
+                let remote_addr = &req.remote_addr();
+                if let Some(token) = get_token(req, self.auth_enabled)? {
+                    let mut tokens = self.sessions.write().unwrap();
+                    if let Some(recv_ip) = remote_addr {
+                        if let Some(Session {
+                            user_ip, expiry, ..
+                        }) = tokens.get(token.as_ref())
+                        {
+                            let curr_time = SystemTime::now();
+                            if !verify_ip(&user_ip, &recv_ip) {
+                                return Err(Status::aborted("Unknown IP Address!"));
+                            }
+                            if curr_time.gt(expiry) {
+                                tokens.remove(token.as_ref());
+                                return Err(Status::aborted("Session Expired"));
+                            }
+                        }
+                    }
                 }
             }
+            None => drop(lock),
         }
 
         Ok(())
@@ -306,6 +315,8 @@ Reason: {}",
     }
 
     fn create_session(&self, request: Request<ClientInfo>) -> Result<SessionInfo, Status> {
+        let mut sessions = self.sessions.write().unwrap();
+        let keys_lock = self.keys.lock().unwrap();
         let end = "-bin";
         let pat = "signature-";
         let mut public_key = String::new();
@@ -317,10 +328,16 @@ Reason: {}",
                         if let Some(key) = key.strip_suffix(end) {
                             if key.contains(pat) {
                                 if let Some(key) = key.split(pat).last() {
-                                    let lock = self.keys.lock().unwrap();
-                                    let message = get_message(b"create-session", &request)?;
-                                    lock.verify_signature(key, &message[..], request.metadata())?;
-                                    public_key.push_str(key);
+                                    if let Some(keys) = &*keys_lock {
+                                        let lock = keys;
+                                        let message = get_message(b"create-session", &request)?;
+                                        lock.verify_signature(
+                                            key,
+                                            &message[..],
+                                            request.metadata(),
+                                        )?;
+                                        public_key.push_str(key);
+                                    }
                                 } else {
                                     return Err(Status::aborted(
                                         "User signing key not found in request!",
@@ -334,10 +351,15 @@ Reason: {}",
                     _ => (),
                 }
             }
-            let mut sessions = self.sessions.write().unwrap();
-            let token = self.new_challenge();
-            let Some(expiry) = SystemTime::now().checked_add(Duration::from_secs(self.session_expiry)) else {
-                return Err(Status::aborted("Could not create expiry for session"));
+            let (token, expiry) = if !self.auth_enabled {
+                ([0u8; 32], SystemTime::now())
+            } else {
+                let expiry =
+                    match SystemTime::now().checked_add(Duration::from_secs(self.session_expiry)) {
+                        Some(v) => v,
+                        None => SystemTime::now(),
+                    };
+                (self.new_challenge(), expiry)
             };
 
             sessions.insert(
@@ -345,7 +367,6 @@ Reason: {}",
                 Session {
                     user_ip,
                     expiry,
-                    public_key,
                     client_info: request.into_inner(),
                 },
             );
@@ -359,26 +380,31 @@ Reason: {}",
     }
 
     fn refresh_session<T>(&self, req: &Request<T>) -> Result<(), Status> {
-        let token = get_token(req)?;
-        let mut sessions = self.sessions.write().unwrap();
-        let session = sessions
-            .get_mut(&token[..])
-            .ok_or(Status::aborted("Session not found!"))?;
+        if let Some(token) = get_token(req, self.auth_enabled)? {
+            let mut sessions = self.sessions.write().unwrap();
+            let session = sessions
+                .get_mut(&token[..])
+                .ok_or(Status::aborted("Session not found!"))?;
 
-        let e = session
-            .expiry
-            .checked_add(Duration::from_secs(self.session_expiry))
-            .ok_or(Status::aborted("Malformed session expiry time!"))?;
+            let e = session
+                .expiry
+                .checked_add(Duration::from_secs(self.session_expiry))
+                .ok_or(Status::aborted("Malformed session expiry time!"))?;
 
-        session.expiry = e;
+            session.expiry = e;
+        }
         Ok(())
     }
 
     fn get_client_info<T>(&self, req: &Request<T>) -> Result<ClientInfo, Status> {
-        let token = get_token(req)?;
         let sessions = self.sessions.write().unwrap();
+        let token = get_token(req, self.auth_enabled)?;
+        let token = match &token {
+            Some(v) => &v[..],
+            None => &[0u8; 32],
+        };
         let session = sessions
-            .get(&token[..])
+            .get(token)
             .ok_or(Status::aborted("Session not found!"))?;
         Ok(session.client_info.clone())
     }
@@ -542,20 +568,27 @@ impl BastionLab for BastionLabState {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
     let mut file = File::open("config.toml")?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
 
+    println!("BastionLab server running...");
+
     let config: BastionLabConfig = toml::from_str(&contents)?;
-    let keys = KeyManagement::load_from_dir(config.public_keys_directory()?)?;
+    let keys = match KeyManagement::load_from_dir(config.public_keys_directory()?) {
+        Ok(keys) => {
+            info!("Authentication is enabled.");
+            Some(keys)
+        }
+        Err(_) => None,
+    };
     let state = BastionLabState::new(keys, config.session_expiry()?);
-    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     let server_cert = fs::read("tls/host_server.pem")?;
     let server_key = fs::read("tls/host_server.key")?;
     let server_identity = Identity::from_pem(&server_cert, &server_key);
-
-    println!("BastionLab server running...");
 
     //TODO: Change it when specifying the TEE will be available
     let tee_mode = String::from("None");

--- a/server/tools/config.toml
+++ b/server/tools/config.toml
@@ -1,3 +1,3 @@
 client_to_enclave_untrusted_url = "https://0.0.0.0:50056"
-public_keys_directory = "keys"
+public_keys_directory = ""
 session_expiry_in_secs = 1500


### PR DESCRIPTION
- Makes optional authentication for BastionLab
- Sets `public_keys_directory` to `""`
- Adds `owners` and `users` to `KeyManagement`.
- Simplifies Key generation
- Adds default port `50056`