### PR TITLE
Feat: detect google colab in client 

### DIFF
--- a/client/src/bastionlab/client.py
+++ b/client/src/bastionlab/client.py
@@ -32,7 +32,7 @@ CLIENT_INFO = ClientInfo(
     platform_release=UNAME.release,
     user_agent="bastionlab_python",
     user_agent_version=app_version,
-    is_colab='google.colab' in sys.modules
+    is_colab="google.colab" in sys.modules,
 )
 
 

--- a/client/src/bastionlab/client.py
+++ b/client/src/bastionlab/client.py
@@ -13,6 +13,7 @@ from .pb.bastionlab_pb2_grpc import SessionServiceStub
 import platform
 import socket
 import getpass
+import sys
 
 
 if TYPE_CHECKING:
@@ -31,6 +32,7 @@ CLIENT_INFO = ClientInfo(
     platform_release=UNAME.release,
     user_agent="bastionlab_python",
     user_agent_version=app_version,
+    is_colab='google.colab' in sys.modules
 )
 
 

--- a/protos/bastionlab.proto
+++ b/protos/bastionlab.proto
@@ -19,6 +19,7 @@ message ClientInfo {
     string platform_release = 5;
     string user_agent = 6;
     string user_agent_version = 7;
+    bool is_colab = 8;
 }
 
 service SessionService {

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bastionlab"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "bastionlab_common"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "bastionlab_learning"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "libc",
  "rand",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "bastionlab_polars"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "bastionlab_torch"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/server/bastionlab_common/src/telemetry.rs
+++ b/server/bastionlab_common/src/telemetry.rs
@@ -107,6 +107,7 @@ struct RequestUserProperties<'a> {
     client_platform_release: Option<&'a str>,
     client_user_agent: Option<&'a str>,
     client_user_agent_version: Option<&'a str>,
+    is_colab: bool,
 }
 
 pub fn setup(platform: String, uid: String, tee: String) -> Result<()> {
@@ -147,6 +148,7 @@ pub fn setup(platform: String, uid: String, tee: String) -> Result<()> {
                         user_properties.client_user_agent = Some(client_info.user_agent.as_ref());
                         user_properties.client_user_agent_version =
                             Some(client_info.user_agent_version.as_ref());
+                        user_properties.is_colab = client_info.is_colab;
                     }
 
                     let event_type = properties.event_type;


### PR DESCRIPTION
The client will now be able to detect if it's running inside a google colab environment, and send the appropriate flag to the telemetry system.