### PR TITLE
Adding PyPi section in installation manual for the sever part.

### DIFF
--- a/docs/docs/tutorials/installation.md
+++ b/docs/docs/tutorials/installation.md
@@ -36,6 +36,12 @@ make dev-install
 ## Installing BastionLab Server
 _______________________________________________________________________________
 
+### From PyPI
+    
+```bash
+pip install bastionlab-server
+```
+
 ### Using the official Docker image
 
 ```bash

--- a/docs/docs/tutorials/installation.md
+++ b/docs/docs/tutorials/installation.md
@@ -37,9 +37,27 @@ make dev-install
 _______________________________________________________________________________
 
 ### From PyPI
+
+For testing purposes only, BastionLab can be installed using our pip package.
+This package is meant to quickly setup a running instance of the server and is particularly useful in colab notebooks.
+The package does not provide any mean to configure the server which makes certain features impossible to use (e.g. authentication).
+For production, please use the Docker image or install the server from source.
     
 ```bash
 pip install bastionlab-server
+```
+
+Once installed, the server can be launched using the following script:
+
+```py
+import bastionlab_server
+srv = bastionlab_server.start()
+```
+
+And closed this way:
+
+```py
+bastionlab_server.stop(srv)
 ```
 
 ### Using the official Docker image

--- a/docs/docs/tutorials/installation.md
+++ b/docs/docs/tutorials/installation.md
@@ -54,7 +54,7 @@ import bastionlab_server
 srv = bastionlab_server.start()
 ```
 
-And closed this way:
+And stoped this way:
 
 ```py
 bastionlab_server.stop(srv)

--- a/docs/docs/tutorials/installation.md
+++ b/docs/docs/tutorials/installation.md
@@ -38,7 +38,7 @@ _______________________________________________________________________________
 
 ### From PyPI
 
-For testing purposes only, BastionLab can be installed using our pip package.
+For testing purposes only, BastionLab server can be installed using our pip package.
 This package is meant to quickly setup a running instance of the server and is particularly useful in colab notebooks.
 The package does not provide any mean to configure the server which makes certain features impossible to use (e.g. authentication).
 For production, please use the Docker image or install the server from source.


### PR DESCRIPTION
As stated in the title, this PR adds a PyPI section in the installation manual for the server part in order to help the user know how to install the server. It only affects the documentation.