### PR TITLE
swap order for join

### DIFF
--- a/client/src/bastionlab/polars/remote_polars.py
+++ b/client/src/bastionlab/polars/remote_polars.py
@@ -378,7 +378,7 @@ class RemoteLazyFrame:
             res,
             Metadata(
                 self._meta._client,
-                [*self._meta._prev_segments, *other._meta._prev_segments],
+                [*other._meta._prev_segments, *self._meta._prev_segments],
             ),
         )
 


### PR DESCRIPTION
-> Just swapped the order we push dataframes to the stack as when using anti and semi join methods, we can see the left and right tables appear to be the wrong way around