### PR TITLE
Rework Serialization

### DIFF
--- a/client/src/bastionlab/polars/utils.py
+++ b/client/src/bastionlab/polars/utils.py
@@ -1,126 +1,53 @@
 from typing import Iterator, Tuple, List
 import torch
 import polars as pl
-from ..pb.bastionlab_polars_pb2 import SendChunk
+import io
+from ..pb.bastionlab_polars_pb2 import SendChunk, FetchChunk
 from .policy import Policy
 
 CHUNK_SIZE = 32 * 1024
 
-END_PATTERN = b"[end]"
-
-
-def create_byte_chunk(data: bytes) -> Iterator[bytes]:
-    """This method chunks bytes into sub-bytes of len `CHUNK_SIZE = 32KB`.
-    If `data` is less than 32KB, it returns directly the `data`.
-    Otherwise, it iteratively yields 32KB until the last chunk of bytes.
-
-    Args:
-        data : bytes
-            Bytes to be chunked.
-
-    Returns:
-        Iterator[bytes]
-    """
-    sent_bytes = 0
-    while sent_bytes < len(data):
-
-        yield bytes(
-            data[sent_bytes : sent_bytes + min(CHUNK_SIZE, len(data) - sent_bytes)]
-        )
-
-        sent_bytes += min(CHUNK_SIZE, len(data) - sent_bytes)
+# TODO PERF: Do a PR on polars/pypolars to add the streaming IPC (apache flight) format to the python interface
+# right now, there is only the file format which requires random access
+# which means, we have to do a full copy to a buffer and we cannot parse it as we go
 
 
 def serialize_dataframe(
     df: pl.DataFrame, policy: Policy, sanitized_columns: List[str]
 ) -> Iterator[SendChunk]:
-    """Converts Polars `DataFrame` to BastionLab `SendChunk`.
-    Receives `polars.internals.dataframe.frame.DataFrame` and uses `__getstate__` to convert `DataFrame`
-    to `List[bytes]`.
+    buf = io.BytesIO()
 
-    `__getstate__()` internally calls `Series.__getstate__()` which converts
-    Polars `Series` to `bytes`, and simply adds `b"[END]"` to the end of each `Series.__getstate__()`.
+    df.write_ipc(buf)
 
-    Args:
-        df : polars.internals.dataframe.frame.DataFrame
-            Polars DataFrame
-        policy : Policy
-            BastionLab Remote DataFrame policy. This specifies which operations can be performed on
-            DataFrames and they specified the data owner.
-        sanitized_columns : List[str]
-            This field contains (sensitive) columns in the DataFrame that are to be removed when a Data Scientist
-            wishes to fetch a query performed on the DataFrame.
-
-    Returns:
-        Iterator[SendChunk]
-    """
-    END_PATTERN = b"[end]"
-    df_bytes = bytearray()
-    for col in df.__getstate__():
-        df_bytes += col.__getstate__() + END_PATTERN
-
+    buf.seek(0)
+    max = len(buf.getvalue())
     first = True
-    for data in create_byte_chunk(df_bytes):
-        cols = ",".join([f'"{col}"' for col in sanitized_columns])
+    while buf.tell() < max:
+        data = buf.read(CHUNK_SIZE)
+
         if first:
-            first = False
-            yield SendChunk(
+            chunk = SendChunk(
                 data=data,
                 policy=policy.serialize(),
-                metadata=f"[{cols}]",
+                sanitized_columns=sanitized_columns,
             )
+            first = False
         else:
-            yield SendChunk(data=data, policy="", metadata="")
+            chunk = SendChunk(data=data)
+
+        yield chunk
 
 
-def deserialize_dataframe(joined_chunks: bytes) -> pl.DataFrame:
-    """Converts `bytes` sent from BastionLab `server` to DataFrame.
+def deserialize_dataframe(chunks: Iterator[bytes]) -> pl.DataFrame:
+    buf = io.BytesIO()
 
-    It notices the `b"[END]"` in the stream of bytes and split the bytes a `List[bytes]`.
-    Each `bytes` in `List[bytes]` represents a single column in the `polars.DataFrame`.
+    for el in chunks:
+        buf.write(el)
 
-    Each column is converted into a `polars.Series` and then later converted to `polars.DataFrame`.
+    buf.seek(0)
+    df = pl.read_ipc(buf)
 
-    >>> for i in range(1, len(dfs)):
-    >>>     out = pl.concat([out, dfs[i]], how="horizontal")
-
-    The above section combines `List[polars.DataFrame]` into a single `polars.DataFrame`.
-
-    Args:
-        joined_chunks : bytes
-            Contains bytes sent from the server.
-
-    Returns:
-        polars.internals.dataframe.frame.DataFrame
-    """
-    step = len(END_PATTERN)
-
-    indexes = [0]
-    for i in range(0, len(joined_chunks) - step + 1):
-        batch = joined_chunks[i : i + step]
-        if batch == END_PATTERN:
-            indexes.append(i)
-    series = []
-    for i in range(0, len(indexes) - 2 + 1):
-        start = indexes[i]
-        end = indexes[i + 1]
-        if start == 0:
-            start = 0
-        else:
-            start += 5
-        series.append(joined_chunks[start:end])
-
-    dfs = []
-    for s in series:
-        out = pl.Series()
-        out.__setstate__(s)
-
-        dfs.append(pl.DataFrame(out))
-
-    out = dfs[0]
-    for i in range(1, len(dfs)):
-        out = pl.concat([out, dfs[i]], how="horizontal")
-    return out
+    return df
 
 
 class ApplyBins(torch.nn.Module):

--- a/client/src/bastionlab/polars/utils.py
+++ b/client/src/bastionlab/polars/utils.py
@@ -15,6 +15,20 @@ CHUNK_SIZE = 32 * 1024
 def serialize_dataframe(
     df: pl.DataFrame, policy: Policy, sanitized_columns: List[str]
 ) -> Iterator[SendChunk]:
+    """Converts Polars `DataFrame` to BastionLab `SendChunk` protobuf message.
+    This currently uses the Apache IPC format.
+    Args:
+        df : polars.internals.dataframe.frame.DataFrame
+            Polars DataFrame
+        policy : Policy
+            BastionLab Remote DataFrame policy. This specifies which operations can be performed on
+            DataFrames and they specified the data owner.
+        sanitized_columns : List[str]
+            This field contains the sensitive columns in the DataFrame that will be removed when a Data Scientist
+            wishes to fetch a query performed on the DataFrame.
+    Returns:
+        Iterator[SendChunk]
+    """
     buf = io.BytesIO()
 
     df.write_ipc(buf)
@@ -39,6 +53,14 @@ def serialize_dataframe(
 
 
 def deserialize_dataframe(chunks: Iterator[bytes]) -> pl.DataFrame:
+    """Converts chunks of `bytes` sent from BastionLab server to DataFrame.
+    This currently uses the Apache IPC format.
+    Args:
+        chunks : Iterator[bytes]
+            Iterator of bytes sent from the server.
+    Returns:
+        polars.internals.dataframe.frame.DataFrame
+    """
     buf = io.BytesIO()
 
     for el in chunks:

--- a/protos/bastionlab_polars.proto
+++ b/protos/bastionlab_polars.proto
@@ -15,9 +15,13 @@ message ReferenceList {
 }
 
 message SendChunk {
+    // Apache IPC format
     bytes data = 1;
+
+    // This is present on the first chunk only.
     string policy = 2;
-    string metadata = 3;
+    // This is present on the first chunk only.
+    repeated string sanitized_columns = 3;
 }
 
 message FetchChunk {

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -216,7 +216,6 @@ dependencies = [
  "bastionlab_common",
  "bastionlab_polars",
  "bastionlab_torch",
- "bincode",
  "bytes",
  "env_logger",
  "hex",
@@ -246,7 +245,6 @@ version = "0.3.7"
 dependencies = [
  "anyhow",
  "base64",
- "bincode",
  "bytes",
  "env_logger",
  "hex",
@@ -288,7 +286,6 @@ dependencies = [
  "anyhow",
  "base64",
  "bastionlab_common",
- "bincode",
  "bytes",
  "hex",
  "http",
@@ -321,7 +318,6 @@ dependencies = [
  "base64",
  "bastionlab_common",
  "bastionlab_learning",
- "bincode",
  "bytes",
  "env_logger",
  "hex",
@@ -345,15 +341,6 @@ dependencies = [
  "uuid",
  "whoami",
  "x509-parser",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -68,12 +68,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "array-init-cursor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
+
+[[package]]
+name = "arrow-format"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df5d25bc6d676271277120c41ef28760fe0a9f070677a58db621c0f983f9c20"
+dependencies = [
+ "planus",
+ "serde",
+]
+
+[[package]]
 name = "arrow2"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6f62e41078c967a4c063fcbdfd3801a2a9632276402c045311c4d73d0845f3"
 dependencies = [
  "ahash 0.7.6",
+ "arrow-format",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -82,10 +99,12 @@ dependencies = [
  "foreign_vec",
  "hash_hasher",
  "lexical-core",
+ "lz4",
  "multiversion",
  "num-traits",
  "simdutf8",
  "strength_reduce",
+ "zstd",
 ]
 
 [[package]]
@@ -1313,6 +1332,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
+dependencies = [
+ "libc",
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1692,15 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "planus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1691dd09e82f428ce8d6310bd6d5da2557c82ff17694d2a32cad7242aea89f"
+dependencies = [
+ "array-init-cursor",
+]
 
 [[package]]
 name = "polars"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,6 @@ prost = { version = "0.8", default-features = false, features = [
 ] }
 tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "net"] }
 tokio-stream = "0.1"
-bincode = "1.3.3"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 serde_json = "1.0.87"

--- a/server/bastionlab_common/Cargo.toml
+++ b/server/bastionlab_common/Cargo.toml
@@ -4,16 +4,14 @@ version = "0.3.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bytes = "1.3.0"
 tonic = { version = "0.5.2", features = ["tls", "transport"] }
 prost = { version = "0.8", default-features = false, features = [
   "prost-derive",
 ] }
-tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "net" ] }
+tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "net"] }
 tokio-stream = "0.1"
-bincode = "1.3.3"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 serde_json = "1.0.87"
@@ -30,14 +28,16 @@ whoami = "1.2.1"
 once_cell = "1.13.1"
 log = "0.4.17"
 env_logger = "0.9.0"
-reqwest = {version = "=0.11.4", default-features = false, features = ["json", "rustls-tls-webpki-roots"]}
-
+reqwest = { version = "=0.11.4", default-features = false, features = [
+  "json",
+  "rustls-tls-webpki-roots"
+] }
 
 [dependencies.uuid]
 version = "1.1.2"
 features = [
-  "v4",                # Lets you generate random UUIDs
-  "fast-rng",          # Use a faster (but still sufficiently random) RNG
+  "v4", # Lets you generate random UUIDs
+  "fast-rng", # Use a faster (but still sufficiently random) RNG
   "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs,
   "serde",
 ]

--- a/server/bastionlab_polars/Cargo.toml
+++ b/server/bastionlab_polars/Cargo.toml
@@ -84,6 +84,7 @@ features = [
   "string_justify",
   "arg_where",
   "date_offset",
+  "ipc_streaming",
 ]
 
 [dependencies.uuid]

--- a/server/bastionlab_polars/Cargo.toml
+++ b/server/bastionlab_polars/Cargo.toml
@@ -12,7 +12,6 @@ prost = { version = "0.8", default-features = false, features = [
 ] }
 tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "net"] }
 tokio-stream = "0.1"
-bincode = "1.3.3"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 serde_json = "1.0.87"

--- a/server/bastionlab_polars/src/lib.rs
+++ b/server/bastionlab_polars/src/lib.rs
@@ -5,7 +5,6 @@ use bastionlab_common::{
     telemetry::{self, TelemetryEventProps},
 };
 use polars::prelude::*;
-use ring::digest;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::fs::{create_dir, read_dir, OpenOptions};
@@ -37,12 +36,18 @@ use access_control::*;
 
 mod utils;
 
+pub mod prelude {
+    pub use bastionlab_common::prelude::*;
+}
+
 pub enum FetchStatus {
     Ok,
     Pending(String),
     Warning(String),
 }
 
+/// This a DataFrame intended to be streamed to the client.
+/// It can be delayed when the data owner's approval is required.
 pub struct DelayedDataFrame {
     future: Pin<Box<dyn Future<Output = Result<DataFrame, Status>> + Send>>,
     fetch_status: FetchStatus,
@@ -385,20 +390,15 @@ impl PolarsService for BastionLabPolars {
 
         let start_time = Instant::now();
 
-        let res = composite_plan.run(self, &user_id)?;
-        let dataframe_bytes: Vec<u8> =
-            df_to_bytes(&res.dataframe)
-                .iter_mut()
-                .fold(Vec::new(), |mut acc, x| {
-                    acc.append(x);
-                    acc
-                }); // Not efficient fix this
+        let mut res = composite_plan.run(self, &user_id)?;
+        // TODO: this isn't really great.. this does a full serialization under the hood
+        let hash = hash_dataset(&mut res.dataframe)
+            .map_err(|e| Status::internal(format!("Polars error: {e}")))?;
 
         let header = get_df_header(&res.dataframe)?;
         let identifier = self.insert_df(res);
 
         let elapsed = start_time.elapsed();
-        let hash = hex::encode(digest::digest(&digest::SHA256, &dataframe_bytes).as_ref());
 
         telemetry::add_event(
             TelemetryEventProps::RunQuery {
@@ -423,19 +423,11 @@ impl PolarsService for BastionLabPolars {
         let token = self.sess_manager.verify_request(&request)?;
 
         let client_info = self.sess_manager.get_client_info(token)?;
-        let df = df_artifact_from_stream(request.into_inner()).await?;
-        let dataframe_bytes: Vec<u8> =
-            df_to_bytes(&df.dataframe)
-                .iter_mut()
-                .fold(Vec::new(), |mut acc, x| {
-                    acc.append(x);
-                    acc
-                }); // Not efficient fix this
+        let (df, hash) = unserialize_dataframe(request.into_inner()).await?;
         let header = get_df_header(&df.dataframe)?;
         let identifier = self.insert_df(df);
 
         let elapsed = start_time.elapsed();
-        let hash = hex::encode(digest::digest(&digest::SHA256, &dataframe_bytes).as_ref());
         telemetry::add_event(
             TelemetryEventProps::SendDataFrame {
                 dataset_name: Some(identifier.clone()),
@@ -464,7 +456,7 @@ impl PolarsService for BastionLabPolars {
                 &request.get_ref().identifier,
                 Some(self.sess_manager.get_client_info(token)?),
             )?;
-            stream_data(df, 32)
+            serialize_delayed_dataframe(df)
         };
         Ok(fut.await)
     }

--- a/server/bastionlab_polars/src/serialization.rs
+++ b/server/bastionlab_polars/src/serialization.rs
@@ -1,94 +1,75 @@
+use super::polars_proto::{fetch_chunk, FetchChunk, SendChunk};
+use crate::prelude::*;
+use crate::{DataFrameArtifact, DelayedDataFrame, FetchStatus};
 use polars::prelude::*;
+use ring::digest;
 use tokio::sync::mpsc;
 use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tonic::{Response, Status};
 
-use crate::{access_control::Policy, DataFrameArtifact, DelayedDataFrame, FetchStatus};
+const CHUNK_SIZE: usize = 32 * 1024;
 
-use super::polars_proto::{fetch_chunk, FetchChunk, SendChunk};
+// TODO PERF: Do a PR on polars/pypolars to add the streaming IPC (apache flight) format to the python interface
+// right now, there is only the file format which requires random access
+// which means, we have to do a full copy to a buffer and we cannot parse it as we go
+// also: polar's IpcStreamReader requires the underlying stream to be Seek; which is weird & does not make sense
 
-pub async fn df_artifact_from_stream(
-    stream: tonic::Streaming<SendChunk>,
-) -> Result<DataFrameArtifact, Status> {
-    let (df_bytes, policy, metadata) = unstream_data(stream).await?;
-    let series = df_bytes
-        .iter()
-        .map(|v| bincode::deserialize(&v[..]).unwrap())
-        .collect::<Vec<Series>>();
-    let df = DataFrame::new(series.clone())
-        .map_err(|_| Status::unknown("Failed to deserialize DataFrame."))?;
-    let policy: Policy = serde_json::from_str(&policy)
-        .map_err(|_| Status::unknown("Failed to deserialize policy."))?;
-    let blacklist: Vec<String> = serde_json::from_str(&metadata)
-        .map_err(|_| Status::unknown("Failed to deserialize metadata."))?;
-    Ok(DataFrameArtifact::new(df, policy, blacklist))
-}
-
-pub fn df_to_bytes(df: &DataFrame) -> Vec<Vec<u8>> {
-    let series = df.get_columns();
-    let series_bytes = series
-        .iter()
-        .map(|s| bincode::serialize(s).unwrap())
-        .collect::<Vec<Vec<u8>>>();
-    series_bytes
-}
-
-pub async fn unstream_data(
+pub async fn unserialize_dataframe(
     mut stream: tonic::Streaming<SendChunk>,
-) -> Result<(Vec<Vec<u8>>, String, String), Status> {
-    let mut columns: Vec<u8> = Vec::new();
+) -> Result<(DataFrameArtifact, String), Status> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut first = true;
     let mut policy = String::new();
-    let mut metadata = String::new();
+    let mut sanitized_columns = Vec::new();
+
+    let mut hasher = digest::Context::new(&digest::SHA256);
 
     while let Some(chunk) = stream.next().await {
         let mut chunk = chunk?;
-        columns.append(&mut chunk.data);
-        policy.push_str(&chunk.policy);
-        metadata.push_str(&chunk.metadata);
+        hasher.update(&chunk.data);
+        buf.append(&mut chunk.data);
+        if first {
+            policy = chunk.policy;
+            sanitized_columns = chunk.sanitized_columns;
+            first = false;
+        }
     }
 
-    let pattern = b"[end]";
-    let mut indexes = vec![0 as usize];
-    indexes.append(
-        &mut columns
-            .windows(pattern.len())
-            .enumerate()
-            .map(
-                |(i, slide): (usize, &[u8])| {
-                    if slide == pattern {
-                        i
-                    } else {
-                        usize::MIN
-                    }
-                },
-            )
-            .filter(|v| v != &usize::MIN)
-            .collect::<Vec<usize>>(),
-    );
-    let output = indexes
-        .windows(2)
-        .map(|r| {
-            let start;
-            if r[0] == 0 {
-                start = r[0];
-            } else {
-                start = r[0] + 5;
-            }
-            let end = r[1];
+    let hash = hex::encode(hasher.finish().as_ref());
 
-            columns[start..end].to_vec()
-        })
-        .collect::<Vec<Vec<u8>>>();
-    Ok((output, policy, metadata))
+    let policy = serde_json::from_str(&policy).map_err(|err| {
+        Status::invalid_argument(format!("Error during the parsing of the policy: {err}"))
+    })?;
+
+    let view = std::io::Cursor::new(&buf);
+    let df = polars::io::ipc::IpcReader::new(view)
+        .finish()
+        .map_err(|err| Status::invalid_argument(format!("Polars error: {err}")))?;
+
+    Ok((DataFrameArtifact::new(df, policy, sanitized_columns), hash))
 }
 
-/// Converts a raw artifact (a header and a binary object) into a stream of chunks to be sent over gRPC.
-pub async fn stream_data(
+// so, to hash a dataset, this does a full serialization; that's kinda bad
+pub fn hash_dataset(df: &mut DataFrame) -> Result<String, PolarsError> {
+    let buf = dataframe_ser_helper(df)?;
+    Ok(hex::encode(digest::digest(&digest::SHA256, &buf).as_ref()))
+}
+
+// This requires &mut because polars is kinda weird about that, but it's not mutated..
+fn dataframe_ser_helper(df: &mut DataFrame) -> Result<Vec<u8>, PolarsError> {
+    let mut buf = Vec::new();
+
+    // PERF: this can be replaced by manually using arrow IPC methods, to avoid this copy
+    let view = std::io::Cursor::new(&mut buf);
+    polars::io::ipc::IpcWriter::new(view).finish(df)?;
+
+    Ok(buf)
+}
+
+pub async fn serialize_delayed_dataframe(
     df: DelayedDataFrame,
-    chunk_size: usize,
 ) -> Response<ReceiverStream<Result<FetchChunk, Status>>> {
     let (tx, rx) = mpsc::channel(4);
-    let pattern = b"[end]";
 
     match df.fetch_status {
         FetchStatus::Pending(reason) => tx
@@ -107,31 +88,42 @@ pub async fn stream_data(
     }
 
     tokio::spawn(async move {
-        let df: DataFrame = match df.future.await {
+        // important things to note about tokio channels:
+        // - send() on them will block until there is space in the queue
+        // - send() returns an error when the receiver has been dropped / .close() has been called on it
+        //   this means that send() will return Err only when the client has "lost interest", has dropped the connection / call
+
+        let mut df: DataFrame = match df.future.await {
             Ok(df) => df,
             Err(e) => {
-                tx.send(Err(e)).await.unwrap(); // fix this
+                // ignore send() error: error means the channel has been closed, ie, client dropped the request.
+                let _ignored = tx.send(Err(e)).await;
                 return;
             }
         };
 
-        let df_bytes = df_to_bytes(&df)
-            .iter_mut()
-            .map(|v| {
-                v.append(&mut pattern.to_vec());
-                v.clone()
-            })
-            .flatten()
-            .collect::<Vec<_>>();
+        let res = dataframe_ser_helper(&mut df)
+            .map_err(|err| Status::internal(format!("Polars error: {err}"))); // this is an internal error
 
-        let raw_bytes: Vec<u8> = df_bytes;
+        let buf = match res {
+            Ok(buf) => buf,
+            Err(err) => {
+                // ignore send() error
+                let _ignored = tx.send(Err(err)).await;
+                return;
+            }
+        };
 
-        for (_, bytes) in raw_bytes.chunks(chunk_size).enumerate() {
-            tx.send(Ok(FetchChunk {
-                body: Some(fetch_chunk::Body::Data(bytes.to_vec())),
-            }))
-            .await
-            .unwrap(); // Fix this
+        for chunk in buf.chunks(CHUNK_SIZE) {
+            let data = FetchChunk {
+                body: Some(fetch_chunk::Body::Data(chunk.into())),
+            };
+
+            if let Err(_ignored) = tx.send(Ok(data)).await {
+                // we have a send() error, meaning client isnt listening anymore
+                // stop the task when this is the case
+                return;
+            }
         }
     });
 

--- a/server/bastionlab_polars/src/utils.rs
+++ b/server/bastionlab_polars/src/utils.rs
@@ -9,7 +9,7 @@ pub fn sanitize_df(df: &mut DataFrame, blacklist: &Vec<String>) {
             None => continue,
         };
         let series = df.get_columns_mut().get_mut(idx).unwrap();
-        *series = Series::new_empty(name, series.dtype());
+        *series = Series::full_null(name, series.len(), series.dtype());
     }
 }
 

--- a/server/bastionlab_torch/Cargo.toml
+++ b/server/bastionlab_torch/Cargo.toml
@@ -24,7 +24,6 @@ prost = { version = "0.8", default-features = false, features = [
 ] }
 tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "net"] }
 tokio-stream = "0.1"
-bincode = "1.3.3"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 serde_json = "1.0.87"


### PR DESCRIPTION
Here are the details:
- Serialization is now using Arrow IPC (feather) as a data format
- It is using the File (randomaccess) version of arrow IPC, there is a Streaming format that is perfect for our usecase, but it's not exposed to the python polars api as of now – the goal would be to switch to this at some point :partying_face: 
  - also, the polars IPCStreamingReader/Writer are problematic since they require the stream to be Seek, and we would have to fix this upstream too
- Tokio channel task is now quite clean
- Hashing of dataframe is still janky, and I would love to see it go away in the future if possible :pray: 
- sanitized_columns is now a `repeated string` (string array) in protobuf, and not json anymore

Closes: #183 
```
rows: 1, time: 0.002671251000265329
rows: 10, time: 0.003582135000215203
rows: 100, time: 0.003072376000091026
rows: 1000, time: 0.0026271389997418737
rows: 10000, time: 0.0033675479999146773
rows: 100000, time: 0.013827925999976287
rows: 1000000, time: 0.1373893780000799
```

Closes #182, because of the changes around the ReceiverStream and the task (see code comments)
