### PR TITLE
Better error messages for invalid logical plans (closes #181)

### DIFF
--- a/client/src/bastionlab/polars/remote_polars.py
+++ b/client/src/bastionlab/polars/remote_polars.py
@@ -113,7 +113,15 @@ class PolarsPlanSegment(CompositePlanSegment):
         Returns:
             str: serialized string of this plan segment
         """
-        return f'{{"PolarsPlanSegment":{self._inner.write_json()}}}'
+
+        # HACK: when getting using the schema attribute, polars returns
+        #  the proper error messages (polars.NotFoundError etc) when it is invalid.
+        #  This is not the case for write_json(), which returns a confusing error
+        #  message. So, we get the schema beforehand :)
+        self._inner.schema
+
+        json_str = self._inner.write_json()
+        return f'{{"PolarsPlanSegment":{json_str}}}'
 
 
 @dataclass


### PR DESCRIPTION
This is a hack. I think I should open an issue/pull request on upstream polars afterwards, what do you think?

New error message
```py
>>> rdf.select(pl.col("i do not exist")).collect().fetch()
[...snip stacktrace...]
NotFoundError: i do not exist
```
This is a an instance of pl.NotFoundError that the user can catch, and in other cases, this hack will also work for
akk if tge other schema error types

(i'd argue `NotFoundError: i do not exist` is still confusing, but this needs to be solved upstream)

Closes #181 