### PR TITLE
CI: fix wrong docker image launched

### DIFF
--- a/.github/workflows/test_client.yml
+++ b/.github/workflows/test_client.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - serverImage: bastionlab
+          - serverImage: mithrilsecuritysas/bastionlab
             client-wheel: client-artifacts
             os: ubuntu-latest
         python-version: [3.9]
@@ -51,7 +51,7 @@ jobs:
         id: run-server
         run: |
           docker kill -f app > /dev/null 2>&1 || true
-          docker run --rm -d -e BASTIONLAB_DISABLE_TELEMETRY=1 -e DISABLE_AUTHENTICATION=1 -p 50056:50056  --name app mithrilsecuritysas/bastionlab:latest
+          docker run --rm -d -e BASTIONLAB_DISABLE_TELEMETRY=1 -e DISABLE_AUTHENTICATION=1 -p 50056:50056  --name app ${{ matrix.serverImage }}:latest
 
       ########## TESTING CLIENT ##########
       - name: Install dependencies for testing


### PR DESCRIPTION
The CI launches the wrong image: it builds and tags bastionlab:latest, but runs mithrilsecurity/bastionlab:latest; which isnt there locally, meaning it pulls it from dockerhub.

This is the reason #187 wasn't passing CI :)