### PR TITLE
[FIX] Fixes dtype error in FetchableLazyFrame

### DIFF
--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+
+import polars as pl
+import logging
+import unittest
+from bastionlab import Connection
+from bastionlab.polars.policy import (
+    Policy,
+    Aggregation,
+    Log,
+)
+
+# from server import launch_server
+
+logging.basicConfig(level=logging.INFO)
+
+
+class TestingConnection(unittest.TestCase):
+    def test_connection(self):
+        connection = Connection("localhost", 50056)
+        client = connection.client
+        self.assertNotEqual(client, None)
+        connection.close()
+
+    def test_dtypes(self):
+        from bastionlab.polars.policy import Policy, TrueRule, Log
+        from functools import reduce
+
+        connection = Connection("localhost")
+        client = connection.client
+        frames = [
+            pl.DataFrame({"a": [[1], [2]]}),
+            pl.DataFrame({"a": ["b", "a"]}),
+            pl.DataFrame({"a": [["b"], ["a"]]}),
+            pl.DataFrame({"a": [1, 2, 4]}),
+            pl.DataFrame({"a": [None]}),
+        ]
+
+        def is_truthy(df1, df2):
+            res = df1 == df2
+            res = res.to_numpy().flatten()
+            res = reduce(lambda a, b: a and b, res)
+            return res
+
+        for df in frames:
+            rdf = client.polars.send_df(
+                df, policy=Policy(TrueRule(), Log(), savable=False)
+            )
+            df2 = rdf.select(pl.all()).collect().fetch()
+
+            self.assertTrue(is_truthy(df, df2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR Closes #185.

It adds these methods to `FetchableLazyFrame`

```python
        def get_dtype(v):
            if isinstance(v, str):
                return getattr(pl, v)()
            else:
                k, v = list(v.items())[0]
                v = get_dtype(v)
                return getattr(pl, k)(v)

        def get_series(name, dtype):
            if isinstance(dtype, str):
                return pl.Series(name, dtype=get_dtype(dtype))
            else:
                return pl.Series(name, values=[[]], dtype=get_dtype(dtype))

```
