### PR TITLE
Fix background color on warning notes in notebook

### DIFF
--- a/docs/material_theme_customization/main.html
+++ b/docs/material_theme_customization/main.html
@@ -68,7 +68,7 @@
 .admonition.hint {
 	background: #1fd;
 }
-.admonition.warning,
+
 .admonition.versionchanged,
 .admonition.deprecated {
 	background: #1d4;


### PR DESCRIPTION
Background for warning notes in notebook didn't get the correct color. It was green and not dark as it should be. 
This PR only affects : 
 - [x] documentation

