### PR TITLE
Removal of cells tags when generating the documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,7 @@ build:
   jobs:
     post_install:
     - bash docs/generate_api_reference.sh
+    - bash docs/remove_cells_tags.sh
 
 mkdocs:
   configuration: mkdocs.yml

--- a/docs/remove_cells_tags.sh
+++ b/docs/remove_cells_tags.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Remove the cells tags of all jupyter notebooks and save them inplace
+
+# Create a list of all the files in the docs/docs/resources/bastionlab directory
+find . -type f -name "*.ipynb" | for file in $(cat); do
+    jupyter nbconvert --ClearMetadataPreprocessor.enabled=True --inplace $file
+done


### PR DESCRIPTION
This PR removes the cells tags when generating the documentation with mkdocs. 
It leaves the files in place but remove the metadata using the `--ClearMetadataPreprocessor.enabled=True` option of nbconvert. 

It affects : 
- [x] documentation