### PR TITLE
Change style admonition

### DIFF
--- a/docs/material_theme_customization/main.html
+++ b/docs/material_theme_customization/main.html
@@ -119,6 +119,10 @@
 
 [dir=ltr] .md-typeset :is(.admonition,details) {
     border-left-width: 1px;
+	border-right-width: 1px;
+	border-top-width: 1px;
+	border-bottom-width: 1px;
+	border-radius: 5px;
 }
 
 

--- a/docs/material_theme_customization/main.html
+++ b/docs/material_theme_customization/main.html
@@ -83,22 +83,42 @@
 /* warning */
 .jp-RenderedHTMLCommon .warning {
 	background: #f0b92d11;
+	/* Add a border to the admonition */
+	border: 1px solid #f0b92d;
+	border-radius: 5px;
+	border-left: 5px solid #f0b92d;
 }
 
 .jp-RenderedHTMLCommon .note {
 	background: #f0b92d11;
+	border: 1px solid #214649;
+	border-radius: 5px;
+	border-left: 5px solid #214649;
 }
 
 .jp-RenderedHTMLCommon .danger {
 	background: #f0b92d11;
+	border: 1px solid #FF1744;
+	border-radius: 5px;
+	border-left: 5px solid #FF1744;
 }
 
 .jp-RenderedHTMLCommon .tip {
 	background: #f0b92d11;
+	border: 1px solid #00BFA5;
+	border-radius: 5px;
+	border-left: 5px solid #00BFA5;
 }
 
 .jp-RenderedHTMLCommon .info {
 	background: #f0b92d11;
+	border: 1px solid #00B8D4;
+	border-radius: 5px;
+	border-left: 5px solid #00B8D4;
+}
+
+[dir=ltr] .md-typeset :is(.admonition,details) {
+    border-left-width: 1px;
 }
 
 

--- a/docs/material_theme_customization/main.html
+++ b/docs/material_theme_customization/main.html
@@ -118,6 +118,7 @@
 }
 
 [dir=ltr] .md-typeset :is(.admonition,details) {
+	background: #f0b92d11;
     border-left-width: 1px;
 	border-right-width: 1px;
 	border-top-width: 1px;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,18 +31,18 @@ theme:
         icon: material/weather-night
   icon:
     admonition:
-      note: octicons/tag-16
-      abstract: octicons/checklist-16
-      info: octicons/info-16
-      tip: octicons/squirrel-16
-      success: octicons/check-16
-      question: octicons/question-16
-      warning: octicons/alert-16
-      failure: octicons/x-circle-16
-      danger: octicons/zap-16
-      bug: octicons/bug-16
-      example: octicons/beaker-16
-      quote: octicons/quote-16
+      note: material/pencil-circle
+      abstract: material/list-box-outline
+      info: material/information-outline
+      tip: material/fire
+      success: material/check
+      question: material/help-circle
+      warning: material/alert
+      failure: material/window-close
+      danger: material/lightning-bolt-circle
+      bug: material/shield-bug
+      example: material/test-tube
+      quote: material/format-quote-close
 
 #Plugins
 plugins:


### PR DESCRIPTION
Admonitions notes in BastionLab's documentation had the old style. New style is now integrated everywhere. 
This change only affects the documentation. 

![Untitled](https://user-images.githubusercontent.com/5594703/214801085-b436afd8-58ad-46d3-9cba-076fdc71a469.png)

