### PR TITLE
Token validation interceptor

### DIFF
--- a/server/bastionlab_common/src/session.rs
+++ b/server/bastionlab_common/src/session.rs
@@ -34,7 +34,7 @@ pub struct Session {
     pub client_info: ClientInfo,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SessionManager {
     keys: Option<Mutex<KeyManagement>>,
     pub sessions: Arc<RwLock<HashMap<[u8; 32], Session>>>,

--- a/server/bastionlab_common/src/session.rs
+++ b/server/bastionlab_common/src/session.rs
@@ -58,6 +58,10 @@ impl SessionManager {
 
     /// Returns the access token in the request
     pub fn get_token<T>(&self, req: &Request<T>) -> Result<Option<Bytes>, Status> {
+        if !self.auth_enabled(){
+            return Ok(None)
+        }
+
         let meta = req
             .metadata()
             .get_bin("accesstoken-bin")

--- a/server/bastionlab_conversion/src/converter.rs
+++ b/server/bastionlab_conversion/src/converter.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use bastionlab_common::common_conversions::*;
-use bastionlab_common::session::SessionManager;
 use bastionlab_polars::BastionLabPolars;
 use bastionlab_torch::BastionLabTorch;
 use tonic::{Request, Response, Status};
@@ -12,20 +11,11 @@ use crate::bastionlab::Reference;
 pub struct Converter {
     torch: Arc<BastionLabTorch>,
     polars: Arc<BastionLabPolars>,
-    sess_manager: Arc<SessionManager>,
 }
 
 impl Converter {
-    pub fn new(
-        torch: Arc<BastionLabTorch>,
-        polars: Arc<BastionLabPolars>,
-        sess_manager: Arc<SessionManager>,
-    ) -> Self {
-        Self {
-            torch,
-            polars,
-            sess_manager,
-        }
+    pub fn new(torch: Arc<BastionLabTorch>, polars: Arc<BastionLabPolars>) -> Self {
+        Self { torch, polars }
     }
 }
 
@@ -35,7 +25,6 @@ impl ConversionService for Converter {
         &self,
         request: Request<ToTensor>,
     ) -> Result<Response<Reference>, Status> {
-        self.sess_manager.verify_request(&request)?;
         let identifier = &request.get_ref().identifier;
 
         let df = self.polars.get_df_unchecked(&identifier)?;

--- a/server/bastionlab_polars/src/composite_plan.rs
+++ b/server/bastionlab_polars/src/composite_plan.rs
@@ -119,11 +119,14 @@ impl CompositePlan {
                         "Could not apply with_row_count: no input data frame",
                     ))?;
                     let df = frame.df.with_row_count(&name, Some(0)).map_err(|e| {
-                        Status::invalid_argument(format!("Error while running with_row_count: {}", e))
+                        Status::invalid_argument(format!(
+                            "Error while running with_row_count: {}",
+                            e
+                        ))
                     })?;
                     let stats = frame.stats;
                     stack.push(StackFrame { df, stats });
-            }
+                }
             }
         }
 

--- a/server/bastionlab_polars/src/lib.rs
+++ b/server/bastionlab_polars/src/lib.rs
@@ -392,7 +392,7 @@ impl PolarsService for BastionLabPolars {
         &self,
         request: Request<Query>,
     ) -> Result<Response<ReferenceResponse>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
 
         let composite_plan: CompositePlan = serde_json::from_str(&request.get_ref().composite_plan)
             .map_err(|e| {
@@ -436,8 +436,7 @@ impl PolarsService for BastionLabPolars {
     ) -> Result<Response<ReferenceResponse>, Status> {
         let start_time = Instant::now();
 
-        let token = self.sess_manager.verify_request(&request)?;
-
+        let token = self.sess_manager.get_token(&request)?;
         let client_info = self.sess_manager.get_client_info(token)?;
         let (df, hash) = unserialize_dataframe(request.into_inner()).await?;
         let header = get_df_header(&df.dataframe)?;
@@ -465,7 +464,7 @@ impl PolarsService for BastionLabPolars {
         &self,
         request: Request<ReferenceRequest>,
     ) -> Result<Response<Self::FetchDataFrameStream>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
 
         let fut = {
             let df = self.get_df(
@@ -481,7 +480,8 @@ impl PolarsService for BastionLabPolars {
         &self,
         request: Request<Empty>,
     ) -> Result<Response<ReferenceList>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
+
         let list = self
             .get_headers()?
             .into_iter()
@@ -498,7 +498,8 @@ impl PolarsService for BastionLabPolars {
         &self,
         request: Request<ReferenceRequest>,
     ) -> Result<Response<ReferenceResponse>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
+
         let identifier = String::from(&request.get_ref().identifier);
         let header = self.get_header(&identifier)?;
         telemetry::add_event(
@@ -514,7 +515,8 @@ impl PolarsService for BastionLabPolars {
         &self,
         request: Request<ReferenceRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
+
         let identifier = &request.get_ref().identifier;
         self.persist_df(identifier)?;
         telemetry::add_event(
@@ -530,7 +532,8 @@ impl PolarsService for BastionLabPolars {
         &self,
         request: Request<ReferenceRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
+
         let identifier = &request.get_ref().identifier;
         let user_id = self.sess_manager.get_user_id(token.clone())?;
         let owner_check = self.sess_manager.verify_if_owner(&user_id)?;

--- a/server/bastionlab_torch/src/lib.rs
+++ b/server/bastionlab_torch/src/lib.rs
@@ -172,7 +172,7 @@ impl TorchService for BastionLabTorch {
         &self,
         request: Request<Streaming<Chunk>>,
     ) -> Result<Response<RemoteDatasetReference>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
         let client_info = self.sess_manager.get_client_info(token)?;
 
         let start_time = Instant::now();
@@ -216,8 +216,8 @@ impl TorchService for BastionLabTorch {
         request: Request<Streaming<Chunk>>,
     ) -> Result<Response<Reference>, Status> {
         let start_time = Instant::now();
+        let token = self.sess_manager.get_token(&request)?;
 
-        let token = self.sess_manager.verify_request(&request)?;
         let client_info = self.sess_manager.get_client_info(token)?;
         let artifact: Artifact<SizedObjectsBytes> = unstream_data(request.into_inner()).await?;
 
@@ -283,7 +283,8 @@ impl TorchService for BastionLabTorch {
         &self,
         request: Request<Reference>,
     ) -> Result<Response<Self::FetchModuleStream>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
+
         let client_info = self.sess_manager.get_client_info(token)?;
         let identifier = request.into_inner().identifier;
 
@@ -344,7 +345,8 @@ impl TorchService for BastionLabTorch {
     }
 
     async fn train(&self, request: Request<TrainConfig>) -> Result<Response<Reference>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
+
         let client_info = self.sess_manager.get_client_info(token)?;
         let config = request.into_inner();
 
@@ -418,7 +420,8 @@ impl TorchService for BastionLabTorch {
     }
 
     async fn test(&self, request: Request<TestConfig>) -> Result<Response<Reference>, Status> {
-        let token = self.sess_manager.verify_request(&request)?;
+        let token = self.sess_manager.get_token(&request)?;
+
         let client_info = self.sess_manager.get_client_info(token)?;
         let config = request.into_inner();
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -10,7 +10,54 @@ use bastionlab_torch::BastionLabTorch;
 use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::path::Path;
+use std::time::SystemTime;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
+use tonic::Status;
+
+#[derive(Clone)]
+struct TokenValidator {
+    sess_manager: Arc<SessionManager>,
+}
+
+impl tonic::service::Interceptor for TokenValidator {
+    fn call(&mut self, req: tonic::Request<()>) -> std::result::Result<tonic::Request<()>, Status> {
+        if !self.sess_manager.auth_enabled() {
+            return Ok(req);
+        }
+        let meta = req
+            .metadata()
+            .get_bin("accesstoken-bin")
+            .ok_or_else(|| Status::invalid_argument("No access token in request metadata"))?;
+
+        let access_token = meta
+            .to_bytes()
+            .map_err(|_| Status::invalid_argument("Could not decode accesstoken"))?;
+
+        let mut tokens = self.sess_manager.sessions.write().expect("Poisoned lock");
+
+        let session = tokens
+            .get(access_token.as_ref())
+            .ok_or_else(|| Status::aborted("Session not found!"))?;
+
+        let recv_ip = &req
+            .remote_addr()
+            .ok_or_else(|| Status::aborted("User IP unavailable"))?;
+
+        // ip verification
+        if session.user_ip.ip() != recv_ip.ip() {
+            return Err(Status::aborted("Unknown IP Address!"));
+        }
+
+        // expiry verification
+        let curr_time = SystemTime::now();
+        if curr_time > session.expiry {
+            tokens.remove(access_token.as_ref());
+            return Err(Status::aborted("Session Expired"));
+        }
+
+        Ok(req)
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -42,7 +89,7 @@ async fn main() -> Result<()> {
         None
     };
 
-    let sess_manager = Arc::new(SessionManager::new(
+    let sess_manager: Arc<SessionManager> = Arc::new(SessionManager::new(
         keys,
         config
             .session_expiry()
@@ -73,6 +120,9 @@ async fn main() -> Result<()> {
     }
     telemetry::add_event(TelemetryEventProps::Started {}, None);
 
+    let token_validator = TokenValidator {
+        sess_manager: sess_manager.clone(),
+    };
     let mut builder = Server::builder()
         .tls_config(ServerTlsConfig::new().identity(server_identity))
         .context("Setting up TLS")?;
@@ -87,11 +137,14 @@ async fn main() -> Result<()> {
         builder.add_service(SessionServiceServer::new(svc))
     };
 
-    let torch_svc = BastionLabTorch::new(sess_manager.clone());
     // Torch
+    let torch_svc = BastionLabTorch::new(sess_manager.clone());
     let builder = {
         use bastionlab_torch::torch_proto::torch_service_server::TorchServiceServer;
-        builder.add_service(TorchServiceServer::new(torch_svc.clone()))
+        builder.add_service(TorchServiceServer::with_interceptor(
+            torch_svc.clone(),
+            token_validator.clone(),
+        ))
     };
 
     // Polars
@@ -105,7 +158,10 @@ async fn main() -> Result<()> {
             Ok(_) => info!("Successfully loaded saved dataframes"),
             Err(_) => info!("There was an error loading saved dataframes"),
         };
-        builder.add_service(PolarsServiceServer::new(polars_svc.clone()))
+        builder.add_service(PolarsServiceServer::with_interceptor(
+            polars_svc.clone(),
+            token_validator.clone(),
+        ))
     };
 
     // Conversion
@@ -114,11 +170,10 @@ async fn main() -> Result<()> {
             conversion_proto::conversion_service_server::ConversionServiceServer,
             converter::Converter,
         };
-        builder.add_service(ConversionServiceServer::new(Converter::new(
-            Arc::new(torch_svc.clone()),
-            Arc::new(polars_svc.clone()),
-            sess_manager.clone(),
-        )))
+        builder.add_service(ConversionServiceServer::with_interceptor(
+            Converter::new(Arc::new(torch_svc.clone()), Arc::new(polars_svc.clone())),
+            token_validator.clone(),
+        ))
     };
 
     let addr = config
@@ -130,5 +185,6 @@ async fn main() -> Result<()> {
 
     // serve!
     builder.serve(addr).await?;
+
     Ok(())
 }


### PR DESCRIPTION
Moves the token validation from each grpc call handler to an interceptor in the server builder that intercepts requests to each service except the session service.