### PR TITLE
Better script for testing notebooks

### DIFF
--- a/.github/scripts/remove_cells.py
+++ b/.github/scripts/remove_cells.py
@@ -23,8 +23,8 @@ def remove_no_execute_cells(nb):
 
 
 # create the output directory if it does not exist
-if not os.path.exists("converted"):
-    os.makedirs("converted")
+if not os.path.exists("tmp"):
+    os.makedirs("tmp")
 
 # traverse all subdirectories and find all .ipynb files
 for root, dirs, files in os.walk("."):
@@ -36,5 +36,5 @@ for root, dirs, files in os.walk("."):
             # remove cells with the no_execute tag
             remove_no_execute_cells(nb)
 
-            # save modified notebook to the converted directory
-            nbformat.write(nb, os.path.join("converted", filename))
+            # save modified notebook to the tmp directory
+            nbformat.write(nb, os.path.join("tmp", filename))

--- a/.github/scripts/test_notebooks.sh
+++ b/.github/scripts/test_notebooks.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+echo "Removing cells..."
+python3 .github/scripts/remove_cells.py
+echo "Downloading datasets..."
+wget 'https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv' -O tmp/titanic.csv
+# wget 'https://raw.githubusercontent.com/rinbaruah/COVID_preconditions_Kaggle/master/Data/covid.csv' -O tmp/covid.csv 
+cp tmp/titanic.csv tmp/train.csv
+
+rm -f ./tmp/resnet_example_notebook.ipynb
+rm -f ./tmp/distilbert_example_notebook.ipynb
+rm -f ./tmp/quick-tour.ipynb
+rm -f ./tmp/fraud_detection.ipynb
+rm -f ./tmp/authentication.ipynb
+
+OUTPUT=""
+ERRORS=0
+N=0
+
+for file in ./tmp/*.ipynb; do 
+    sed -i 's/"!pip install bastionlab"/""/g' $file
+    sed -i 's/"srv = bastionlab_server.start()"/""/g' $file
+    sed -i 's/"bastionlab_server.stop(srv)"/""/g' $file
+    echo "Running $file..."
+    if jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.timeout=600 --output-dir=./tmp $file; then
+        OUTPUT+="... $file: OK!\n"
+    else
+        OUTPUT+="... $file: ERROR!\n"
+        ERRORS=$[ $ERRORS + 1 ]
+    fi
+    N=$[ $N + 1 ]
+done
+
+echo
+echo "Summary:"
+echo -e $OUTPUT
+echo "$ERRORS errors out of $N notebooks!"
+
+if [ $ERRORS -gt 0 ]; then
+    exit 1
+fi

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -59,19 +59,4 @@ jobs:
         run: |
           pip install ./client
           pip install jupyter nbconvert
-          python .github/scripts/remove_cells.py
-          wget 'https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv'
-          cp titanic.csv converted/train.csv
-          cp titanic.csv converted/titanic.csv
-          rm ./converted/resnet_example_notebook.ipynb
-          rm ./converted/distilbert_example_notebook.ipynb
-          rm ./converted/nbagg_uat.ipynb
-          rm ./converted/quick-tour.ipynb
-          rm ./converted/fraud_detection.ipynb
-          rm ./converted/authentication.ipynb
-          for file in ./converted/*.ipynb; do 
-            sed -i 's/"!pip install bastionlab"/""/g' $file
-            sed -i 's/"srv = bastionlab_server.start()"/""/g' $file
-            sed -i 's/"bastionlab_server.stop(srv)"/""/g' $file
-            jupyter nbconvert --execute --to notebook --inplace --ExecutePreprocessor.timeout=600 --output-dir=./converted $file
-          done
+          bash .github/scripts/test_notebooks.sh

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ ex.c
 *.key.pem
 *.html
 docs/docs/resources/bastionlab/**/*.md
+
+# Notebook tests
+/tmp


### PR DESCRIPTION
As part of my work for making revamping the aggregation check and integrating DP, I got tired of running the notebooks by hand and decided to move the notebook-test part of the CI into a proprer script

This script now outputs something like this at the end of the script:
```
Summary:
... ./tmp/combining_datasets.ipynb: OK!
... ./tmp/covid_cleaning_exploration.ipynb: ERROR!
... ./tmp/data_cleaning.ipynb: OK!
... ./tmp/data_conversion.ipynb: OK!
... ./tmp/defining_policy_privacy.ipynb: OK!
... ./tmp/normalization.ipynb: ERROR!
... ./tmp/saving_dataframes.ipynb: OK!
... ./tmp/SQL_queries.ipynb: OK!
... ./tmp/visualization.ipynb: OK!

2 errors out of 9 notebooks!
```
and exit with an error code when there has been at least one error (so that the CI still fails in this case)
This is a little change but this should make it easier to work on bastionlab.

Run it with `bash .github/scripts/test_notebooks.sh`